### PR TITLE
Update 02-input-parameters.ipynb

### DIFF
--- a/training/advanced_stream/session_2/02-input-parameters.ipynb
+++ b/training/advanced_stream/session_2/02-input-parameters.ipynb
@@ -21,15 +21,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pybamm\n",
     "import numpy as np"
@@ -89,21 +81,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Average time taken: 0.067 seconds\n"
+      "Average time taken: 0.078 seconds\n"
      ]
     }
    ],
    "source": [
     "import time\n",
     "\n",
-    "average_time = -1\n",
+    "average_time = 0\n",
     "n = 9\n",
     "model = pybamm.lithium_ion.SPM()\n",
     "solver = pybamm.IDAKLUSolver()\n",
@@ -114,7 +106,7 @@
     "    sim = pybamm.Simulation(model, solver=solver, parameter_values=params)\n",
     "    sol = sim.solve([-1, 3600])\n",
     "    t_evals = np.linspace(-1, 3600, 100)\n",
-    "    voltage = sol[\"Terminal voltage [V]\"](t_evals)\n",
+    "    voltage = sol[\"Voltage [V]\"](t_evals)\n",
     "    time_end = time.perf_counter()\n",
     "    average_time += time_end - time_start\n",
     "print(f\"Average time taken: {average_time / n:.3f} seconds\")"
@@ -131,14 +123,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Average time taken: 0.018 seconds\n"
+      "Average time taken: 0.009 seconds\n"
      ]
     }
    ],
@@ -170,61 +162,6 @@
    "metadata": {},
    "source": [
     "## Limitations\n",
-    "\n",
-    "### Increased solve time\n",
-    "\n",
-    "It is interesting to compare the time taken to solve the model with an input parameter to the time taken to solve the original model. There is a good reason why step 1 of the pipeline replaces parameters with values: this allows PyBaMM to simplify the equations significantly by combining terms and performing operations between values, rather than between symbols. E.g. if your model has parameters `a` and `b` and has the equation `a*b` somewhere in the model, if both `a` and `b` are replaced by values, PyBaMM can simplify this to `c`, where `c = a*b`. If either `a` or `b` is an input parameter, PyBaMM cannot simplify this equation, and will have to evaluate `a*b` at each time step of the simulation. \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Time taken without input parameter: 0.0011 seconds\n",
-      "Time taken with input parameter: 0.0021 seconds\n"
-     ]
-    }
-   ],
-   "source": [
-    "model = pybamm.lithium_ion.SPM()\n",
-    "solver = pybamm.IDAKLUSolver()\n",
-    "sim = pybamm.Simulation(model, solver=solver)\n",
-    "sol = sim.solve([0, 3600])\n",
-    "start_time = time.perf_counter()\n",
-    "sol = sim.solve([0, 3600])\n",
-    "end_time = time.perf_counter()\n",
-    "print(f\"Time taken without input parameter: {end_time - start_time:.4f} seconds\")\n",
-    "\n",
-    "\n",
-    "model = pybamm.lithium_ion.SPM()\n",
-    "solver = pybamm.IDAKLUSolver()\n",
-    "params = model.default_parameter_values\n",
-    "params[\"Current function [A]\"] = \"[input]\"\n",
-    "sim = pybamm.Simulation(model, solver=solver, parameter_values=params)\n",
-    "sol = sim.solve([0, 3600], inputs={\"Current function [A]\": 1.0})\n",
-    "start_time = time.perf_counter()\n",
-    "sol = sim.solve([0, 3600], inputs={\"Current function [A]\": 1.0})\n",
-    "end_time = time.perf_counter()\n",
-    "print(f\"Time taken with input parameter: {end_time - start_time:.4f} seconds\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "So you can see that input parameters come with a cost: they are useful to avoid having to re-build your model each time you want to change a parameter, but they also produce a set of final equations that are more complex and take longer to solve. You should still use input parameters when you need to re-run simulations with different parameters, after all the time taken to perform the discretisation is often much longer than the time taken to solve the model. However, you should be aware that using input parameters will slow down the simulation, and you should be careful to only use them where necessary."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
     "\n",
     "### Geometric parameters cannot be input parameters (using the default mesh)\n",
     "\n",
@@ -333,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The section about input parameters affecting the solve time is not set up correctly. It uses two different C-rates to test the simulation runtime. When the C-rates are the same, the difference is negligible. I removed this section.